### PR TITLE
Fix snpcmc graph y domain (min max)

### DIFF
--- a/src/components/LineGraph/LineGraph1d.js
+++ b/src/components/LineGraph/LineGraph1d.js
@@ -50,35 +50,39 @@ function Index1d() {
       response.data[i].SNP = Math.ceil(response.data[i].SNP * 100) / 100;
       response.data[i].CMC = Math.ceil(response.data[i].CMC * 100) / 100;
     }
-    //console.log(response.data);
+    console.log(response.data);
     setRes(response.data);
 
-    let snp_minmax = [0, 0];
-    let cmc_minmax = [0, 0];
-    snp_minmax[0] = response.data
-      .map((v) => v.SNP)
-      .reduce((min, cur) =>
-        Number(min) > Number(cur) ? Number(cur) : Number(min)
-      );
-    snp_minmax[1] = response.data
-      .map((v) => v.SNP)
-      .reduce((max, cur) =>
-        Number(max) < Number(cur) ? Number(cur) : Number(max)
-      );
-    cmc_minmax[0] = response.data
-      .map((v) => v.CMC)
-      .reduce((min, cur) =>
-        Number(min) > Number(cur) ? Number(cur) : Number(min)
-      );
-    cmc_minmax[1] = response.data
-      .map((v) => v.CMC)
-      .reduce((max, cur) =>
-        Number(max) < Number(cur) ? Number(cur) : Number(max)
-      );
+    // let snp_minmax = [0, 0];
+    // let cmc_minmax = [0, 0];
+    // snp_minmax[0] = response.data
+    //   .map((v) => v.SNP)
+    //   .reduce((min, cur) =>
+    //     Number(min) > Number(cur) ? Number(cur) : Number(min)
+    //   );
+    // snp_minmax[1] = response.data
+    //   .map((v) => v.SNP)
+    //   .reduce((max, cur) =>
+    //     Number(max) < Number(cur) ? Number(cur) : Number(max)
+    //   );
+    // cmc_minmax[0] = response.data
+    //   .map((v) => v.CMC)
+    //   .reduce((min, cur) =>
+    //     Number(min) > Number(cur) ? Number(cur) : Number(min)
+    //   );
+    // cmc_minmax[1] = response.data
+    //   .map((v) => v.CMC)
+    //   .reduce((max, cur) =>
+    //     Number(max) < Number(cur) ? Number(cur) : Number(max)
+    //   );
 
+    // setMinMax([
+    //   Math.min(snp_minmax[0], cmc_minmax[0]) - 1,
+    //   Math.max(snp_minmax[1], cmc_minmax[1]) + 1,
+    // ]);
     setMinMax([
-      Math.min(snp_minmax[0], cmc_minmax[0]) - 1,
-      Math.max(snp_minmax[1], cmc_minmax[1]) + 1,
+      Math.min(Math.min(...response.data.map(v => v.SNP)), Math.min(...response.data.map(v => v.CMC))) - 1,
+      Math.max(Math.max(...response.data.map(v => v.SNP)), Math.max(...response.data.map(v => v.CMC))) + 1,
     ]);
   };
 
@@ -220,6 +224,7 @@ function Index1d() {
   //   setRes(resTemp);
   //   return res;
   // };
+  console.log(minMax);
 
   return (
     <div>

--- a/src/components/LineGraph/LineGraph1mo.js
+++ b/src/components/LineGraph/LineGraph1mo.js
@@ -32,32 +32,36 @@ function Index1mo() {
     // console.log(response.data);
     setRes(response.data);
 
-    let snp_minmax = [0, 0];
-    let cmc_minmax = [0, 0];
-    snp_minmax[0] = response.data
-      .map((v) => v.SNP)
-      .reduce((min, cur) =>
-        Number(min) > Number(cur) ? Number(cur) : Number(min)
-      );
-    snp_minmax[1] = response.data
-      .map((v) => v.SNP)
-      .reduce((max, cur) =>
-        Number(max) < Number(cur) ? Number(cur) : Number(max)
-      );
-    cmc_minmax[0] = response.data
-      .map((v) => v.CMC)
-      .reduce((min, cur) =>
-        Number(min) > Number(cur) ? Number(cur) : Number(min)
-      );
-    cmc_minmax[1] = response.data
-      .map((v) => v.CMC)
-      .reduce((max, cur) =>
-        Number(max) < Number(cur) ? Number(cur) : Number(max)
-      );
+    // let snp_minmax = [0, 0];
+    // let cmc_minmax = [0, 0];
+    // snp_minmax[0] = response.data
+    //   .map((v) => v.SNP)
+    //   .reduce((min, cur) =>
+    //     Number(min) > Number(cur) ? Number(cur) : Number(min)
+    //   );
+    // snp_minmax[1] = response.data
+    //   .map((v) => v.SNP)
+    //   .reduce((max, cur) =>
+    //     Number(max) < Number(cur) ? Number(cur) : Number(max)
+    //   );
+    // cmc_minmax[0] = response.data
+    //   .map((v) => v.CMC)
+    //   .reduce((min, cur) =>
+    //     Number(min) > Number(cur) ? Number(cur) : Number(min)
+    //   );
+    // cmc_minmax[1] = response.data
+    //   .map((v) => v.CMC)
+    //   .reduce((max, cur) =>
+    //     Number(max) < Number(cur) ? Number(cur) : Number(max)
+    //   );
 
+    // setMinMax([
+    //   Math.min(snp_minmax[0], cmc_minmax[0]) - 1,
+    //   Math.max(snp_minmax[1], cmc_minmax[1]) + 1,
+    // ]);
     setMinMax([
-      Math.min(snp_minmax[0], cmc_minmax[0]) - 1,
-      Math.max(snp_minmax[1], cmc_minmax[1]) + 1,
+      Math.min(Math.min(...response.data.map(v => v.SNP)), Math.min(...response.data.map(v => v.CMC))) - 1,
+      Math.max(Math.max(...response.data.map(v => v.SNP)), Math.max(...response.data.map(v => v.CMC))) + 1,
     ]);
   };
 

--- a/src/components/LineGraph/LineGraph1y.js
+++ b/src/components/LineGraph/LineGraph1y.js
@@ -29,35 +29,39 @@ function Index1y() {
       response.data[i].SNP = Math.ceil(response.data[i].SNP * 100) / 100;
       response.data[i].CMC = Math.ceil(response.data[i].CMC * 100) / 100;
     }
-    //console.log(response.data);
+    console.log(response.data);
     setRes(response.data);
 
-    let snp_minmax = [0, 0];
-    let cmc_minmax = [0, 0];
-    snp_minmax[0] = response.data
-      .map((v) => v.SNP)
-      .reduce((min, cur) =>
-        Number(min) > Number(cur) ? Number(cur) : Number(min)
-      );
-    snp_minmax[1] = response.data
-      .map((v) => v.SNP)
-      .reduce((max, cur) =>
-        Number(max) < Number(cur) ? Number(cur) : Number(max)
-      );
-    cmc_minmax[0] = response.data
-      .map((v) => v.CMC)
-      .reduce((min, cur) =>
-        Number(min) > Number(cur) ? Number(cur) : Number(min)
-      );
-    cmc_minmax[1] = response.data
-      .map((v) => v.CMC)
-      .reduce((max, cur) =>
-        Number(max) < Number(cur) ? Number(cur) : Number(max)
-      );
+    // let snp_minmax = [0, 0];
+    // let cmc_minmax = [0, 0];
+    // snp_minmax[0] = response.data
+    //   .map((v) => v.SNP)
+    //   .reduce((min, cur) =>
+    //     Number(min) > Number(cur) ? Number(cur) : Number(min)
+    //   );
+    // snp_minmax[1] = response.data
+    //   .map((v) => v.SNP)
+    //   .reduce((max, cur) =>
+    //     Number(max) < Number(cur) ? Number(cur) : Number(max)
+    //   );
+    // cmc_minmax[0] = response.data
+    //   .map((v) => v.CMC)
+    //   .reduce((min, cur) =>
+    //     Number(min) > Number(cur) ? Number(cur) : Number(min)
+    //   );
+    // cmc_minmax[1] = response.data
+    //   .map((v) => v.CMC)
+    //   .reduce((max, cur) =>
+    //     Number(max) < Number(cur) ? Number(cur) : Number(max)
+    //   );
 
+    // setMinMax([
+    //   Math.min(snp_minmax[0], cmc_minmax[0]) - 1,
+    //   Math.max(snp_minmax[1], cmc_minmax[1]) + 1,
+    // ]);
     setMinMax([
-      Math.min(snp_minmax[0], cmc_minmax[0]) - 1,
-      Math.max(snp_minmax[1], cmc_minmax[1]) + 1,
+      Math.min(Math.min(...response.data.map(v => v.SNP)), Math.min(...response.data.map(v => v.CMC))) - 1,
+      Math.max(Math.max(...response.data.map(v => v.SNP)), Math.max(...response.data.map(v => v.CMC))) + 1,
     ]);
   };
 


### PR DESCRIPTION
S&P, CMC 그래프의 y축 domain(min-1 ~ max+1)을 구할 때 reduce를 사용하던 것을 스프레드 문법을 사용하여 Math.min, Math.max로 변경